### PR TITLE
Eliminate g++ -Wreorder warnings

### DIFF
--- a/include/anyrpc/connection.h
+++ b/include/anyrpc/connection.h
@@ -82,14 +82,13 @@ private:
     log_define("AnyRPC.RpcHandler");
 
     RpcHandler* handler_;               //!< Function pointer to RPC handler
-    bool matchAnyContentType_;          //!< Flag indicating that any content-type can be used
 #if defined(ANYRPC_REGEX)
     std::regex requestContentType_;     //!< Regular express to match with the HTTP request content-type
 #else
     std::string requestContentType_;    //!< String to match with the HTTP request content-type
 #endif // #if defined(ANYRPC_REGEX)
-
     std::string responseContentType_;   //!< String to use in the HTTP response content-type field
+    bool matchAnyContentType_;          //!< Flag indicating that any content-type can be used
 };
 
 //! A list of RpcContentHandlers that can be used to process a message

--- a/include/anyrpc/error.h
+++ b/include/anyrpc/error.h
@@ -127,8 +127,8 @@ public:
     void Clear() { code_ = AnyRpcErrorNone; }
 
 private:
-    std::string message_;       //!< Message associated with the error
     int code_;                  //!< Code for the error
+    std::string message_;       //!< Message associated with the error
     std::size_t offset_;        //!< Offset from the start of the document for a parse error
 };
 


### PR DESCRIPTION
Rearrange declaration order to be identical to member initialization order.
Different order causes -Wreorder warning if compiling with g++ and might in general cause other side effects.
In this case no errors actually occur, but changing order seems to be the better solution then turning off warning for the whole project.
More information can be found on https://stackoverflow.com/questions/1828037/whats-the-point-of-g-wreorder.