### PR TITLE
Fix bug of detecting empty tag

### DIFF
--- a/src/xml/xmlreader.cpp
+++ b/src/xml/xmlreader.cpp
@@ -319,6 +319,7 @@ int XmlReader::GetNextTag()
     while (!is_.Eof() && !done)
     {
         tag[tagLength] = is_.Get();
+        if (tag[tagLength] == ' ') continue;
         if (tag[tagLength] == '>')
         {
             tag[tagLength] = 0;
@@ -332,6 +333,7 @@ int XmlReader::GetNextTag()
                 anyrpc_throw(AnyRpcErrorTagInvalid, "Parse error with xml tag");
             }
             emptyTagFound = true;
+            tag[tagLength] = 0;
             done = true;
         }
         else


### PR DESCRIPTION
Skipping space inside empty tag, like `<params />`.
Add ending character of tag string.