### PR TITLE
Debug messagepack server for notifications

### DIFF
--- a/src/messagepack/messagepackserver.cpp
+++ b/src/messagepack/messagepackserver.cpp
@@ -104,8 +104,8 @@ bool MessagePackRpcHandler(MethodManager* manager, char* request, size_t length,
             // Should a notification produce a fault response if it is not formatted correctly?
 			// The protocol specification indicates no response should be given to a notification.
             Value& type = message[0];
-            Value& method = message[2];
-            Value& params = message[3];
+            Value& method = message[1];
+            Value& params = message[2];
 
             if (!type.IsInt() && (type.GetInt() != 1))
             {


### PR DESCRIPTION
The request on client side:

```
    if (notification)
    {
        requestId = 0;
        request.SetSize(3);
        request[0] = 2;
        request[1] = method;
        request[2].Assign(params);      // assign so that the structure doesn't need to be copied
    }
    else
    {
        requestId = GetNextId();
        request.SetSize(4);
        request[0] = 0;
        request[1] = requestId;
        request[2] = method;
        request[3].Assign(params);      // assign so that the structure doesn't need to be copied
    }
```
did not fit to the request handler on server side.