### PR TITLE
Debug ServerTP::ThreadStarter() to allow multiple starts and stops

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -522,7 +522,8 @@ void ServerTP::ThreadStarter()
     workerBlock_.notify_all();
     for (std::thread &worker: workers_)
         worker.join();
-
+	workers_.clear();
+	
     // shutdown the rest of the system
     Shutdown();
     threadRunning_ = false;


### PR DESCRIPTION
Previously the problem was:
If a StopThread() is called for a ServerTP, the ThreadStarter() function joins all the worker threads. However the std::vector<std::thread> workers_ is not cleared, it now consists of empty threads. If you restart the server, the vector will contain the old, invalid threads and the new ones. On the next StopThread() the worker.join() on the old threads throws an uncaught exception.