### PR TITLE
Disable "-Wunused-function" warnings for log_define and fix a typo

### DIFF
--- a/include/anyrpc/logger.h
+++ b/include/anyrpc/logger.h
@@ -21,6 +21,12 @@
 #ifndef ANYRPC_LOGGER_H
 #define ANYRPC_LOGGER_H
 
+#ifdef __GNUC__
+#define ATTR_UNUSED  __attribute__ ((unused))
+#else
+#define ATTR_UNUSED
+#endif
+
 #if BUILD_WITH_LOG4CPLUS
 # include <log4cplus/log4cplus.h>
 # define InitializeLogger() \
@@ -40,7 +46,7 @@
 // Define the logger that will be used in the current namespace or class.
 #if defined(BUILD_WITH_LOG4CPLUS)
 # define log_define(category) \
-   static log4cplus::Logger _getStaticLogger()   \
+   ATTR_UNUSED static log4cplus::Logger _getStaticLogger()   \
    {  \
 	 static bool _staticLoggerDefined = false; \
      static log4cplus::Logger _staticLogger; \

--- a/include/anyrpc/method.h
+++ b/include/anyrpc/method.h
@@ -55,7 +55,7 @@ protected:
     std::string help_;
     bool deleteOnRemove_;
 
-    log_define("AnyRcp.Method");
+    log_define("AnyRpc.Method");
 };
 
 //! A MethodFunction is created with a function pointer that is call by the Execute method.


### PR DESCRIPTION
Please see commit messages for more information