### PR TITLE
Add functionality for information on ip and port of host and peer

### DIFF
--- a/include/anyrpc/client.h
+++ b/include/anyrpc/client.h
@@ -120,12 +120,12 @@ public:
     virtual bool GetPostResult(Value& result);
     virtual bool Notify(const char* method, Value& params, Value& result);
 
-	//! Start the client and connect to server
-	virtual bool Start();
-	//! Get ip and port of connection (local)
-	virtual bool GetSockInfo(std::string& ip, unsigned& port) const { return socket_.GetSockInfo(ip, port); }
-	//! Get ip and port of the host (remote)
-	virtual bool GetPeerInfo(std::string& ip, unsigned& port) const { return socket_.GetPeerInfo(ip, port); }
+    //! Start the client and connect to server
+    virtual bool Start();
+    //! Get ip and port of connection (local)
+    virtual bool GetSockInfo(std::string& ip, unsigned& port) const { return socket_.GetSockInfo(ip, port); }
+    //! Get ip and port of the host (remote)
+    virtual bool GetPeerInfo(std::string& ip, unsigned& port) const { return socket_.GetPeerInfo(ip, port); }
 
 protected:
     log_define("AnyRPC.Client");

--- a/include/anyrpc/client.h
+++ b/include/anyrpc/client.h
@@ -120,6 +120,13 @@ public:
     virtual bool GetPostResult(Value& result);
     virtual bool Notify(const char* method, Value& params, Value& result);
 
+	//! Start the client and connect to server
+	virtual bool Start();
+	//! Get ip and port of connection (local)
+	virtual bool GetSockInfo(std::string& ip, unsigned& port) const { return socket_.GetSockInfo(ip, port); }
+	//! Get ip and port of the host (remote)
+	virtual bool GetPeerInfo(std::string& ip, unsigned& port) const { return socket_.GetPeerInfo(ip, port); }
+
 protected:
     log_define("AnyRPC.Client");
 

--- a/include/anyrpc/connection.h
+++ b/include/anyrpc/connection.h
@@ -145,6 +145,11 @@ public:
     //! Get the time when the last RPC transaction took place
     virtual time_t GetLastTransactionTime() { return lastTransactionTime_; }
 
+	//! Get ip and port of connection (local)
+	virtual bool GetSockInfo(std::string& ip, unsigned& port) const { return socket_.GetSockInfo(ip, port); }
+	//! Get ip and port of client (remote)
+	virtual bool GetPeerInfo(std::string& ip, unsigned& port) const { return socket_.GetPeerInfo(ip, port); }
+
 #if defined(ANYRPC_THREADING)
     void StartThread();
     void StopThread(bool waitForJoin=true);

--- a/include/anyrpc/connection.h
+++ b/include/anyrpc/connection.h
@@ -145,10 +145,10 @@ public:
     //! Get the time when the last RPC transaction took place
     virtual time_t GetLastTransactionTime() { return lastTransactionTime_; }
 
-	//! Get ip and port of connection (local)
-	virtual bool GetSockInfo(std::string& ip, unsigned& port) const { return socket_.GetSockInfo(ip, port); }
-	//! Get ip and port of client (remote)
-	virtual bool GetPeerInfo(std::string& ip, unsigned& port) const { return socket_.GetPeerInfo(ip, port); }
+    //! Get ip and port of connection (local)
+    virtual bool GetSockInfo(std::string& ip, unsigned& port) const { return socket_.GetSockInfo(ip, port); }
+    //! Get ip and port of client (remote)
+    virtual bool GetPeerInfo(std::string& ip, unsigned& port) const { return socket_.GetPeerInfo(ip, port); }
 
 #if defined(ANYRPC_THREADING)
     void StartThread();

--- a/include/anyrpc/server.h
+++ b/include/anyrpc/server.h
@@ -93,12 +93,12 @@ public:
     void StopThread();
 #endif // defined(ANYRPC_THREADING)
 
-	//! Get ip and port of the server (local)
-	virtual bool GetMainSockInfo(std::string& ip, unsigned& port) const { return socket_.GetSockInfo(ip, port); }
-	//! Get ip and port of sockets of all connections (local)
-	virtual void GetConnectionsSockInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const;
-	//! Get ip and port of peers of all connections (remote)
-	virtual void GetConnectionsPeerInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const;
+    //! Get ip and port of the server (local)
+    virtual bool GetMainSockInfo(std::string& ip, unsigned& port) const { return socket_.GetSockInfo(ip, port); }
+    //! Get ip and port of sockets of all connections (local)
+    virtual void GetConnectionsSockInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const;
+    //! Get ip and port of peers of all connections (remote)
+    virtual void GetConnectionsPeerInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const;
 
 protected:
     log_define("AnyRPC.Server");

--- a/include/anyrpc/server.h
+++ b/include/anyrpc/server.h
@@ -93,6 +93,12 @@ public:
     void StopThread();
 #endif // defined(ANYRPC_THREADING)
 
+	//! Get ip and port of the server (local)
+	virtual bool GetMainSockInfo(std::string& ip, unsigned& port) const { return socket_.GetSockInfo(ip, port); }
+	//! Get ip and port of sockets of all connections (local)
+	virtual void GetConnectionsSockInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const;
+	//! Get ip and port of peers of all connections (remote)
+	virtual void GetConnectionsPeerInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const;
 
 protected:
     log_define("AnyRPC.Server");

--- a/include/anyrpc/socket.h
+++ b/include/anyrpc/socket.h
@@ -70,6 +70,11 @@ public:
     bool WaitReadable(int timeout=-1);
     bool WaitWritable(int timeout=-1);
 
+	//! Get information on ip and port of socket (local)
+	virtual bool GetSockInfo(std::string& ip, unsigned& port) const;
+	//! Get information on ip and port of peer (remote)
+	virtual bool GetPeerInfo(std::string& ip, unsigned& port) const;
+
 protected:
     void SetLastError();
 

--- a/include/anyrpc/socket.h
+++ b/include/anyrpc/socket.h
@@ -70,10 +70,10 @@ public:
     bool WaitReadable(int timeout=-1);
     bool WaitWritable(int timeout=-1);
 
-	//! Get information on ip and port of socket (local)
-	virtual bool GetSockInfo(std::string& ip, unsigned& port) const;
-	//! Get information on ip and port of peer (remote)
-	virtual bool GetPeerInfo(std::string& ip, unsigned& port) const;
+    //! Get information on ip and port of socket (local)
+    virtual bool GetSockInfo(std::string& ip, unsigned& port) const;
+    //! Get information on ip and port of peer (remote)
+    virtual bool GetPeerInfo(std::string& ip, unsigned& port) const;
 
 protected:
     void SetLastError();

--- a/include/anyrpc/value.h
+++ b/include/anyrpc/value.h
@@ -184,7 +184,7 @@ public:
     Value& AddMember(const char* str, Value& value, bool copy=true) { return AddMember(str, strlen(str), value, copy); }
     //! Add member with string key and value.
     Value& AddMember(const std::string& str, Value& value) { return AddMember(str.c_str(), str.length(), value); }
-    //! Add member with key.  The key must be a String.  The value will be invalid until assigned.
+	//! Add member with key.  The key must be a String. The value will be invalid until assigned.
     Value& AddMember(Value& key, bool copy=true);
     //! Add member with string key.  The value will be invalid until assigned.
     Value& AddMember(const char* str, std::size_t length, bool copy=true);

--- a/include/anyrpc/value.h
+++ b/include/anyrpc/value.h
@@ -184,7 +184,7 @@ public:
     Value& AddMember(const char* str, Value& value, bool copy=true) { return AddMember(str, strlen(str), value, copy); }
     //! Add member with string key and value.
     Value& AddMember(const std::string& str, Value& value) { return AddMember(str.c_str(), str.length(), value); }
-	//! Add member with key.  The key must be a String. The value will be invalid until assigned.
+    //! Add member with key. The key must be a String. The value will be invalid until assigned.
     Value& AddMember(Value& key, bool copy=true);
     //! Add member with string key.  The value will be invalid until assigned.
     Value& AddMember(const char* str, std::size_t length, bool copy=true);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -303,15 +303,15 @@ unsigned Client::GetTimeLeft()
 //! Start the client and connect to server
 bool Client::Start()
 {
-	Value result = Value(ValueType::InvalidType);
-	gettimeofday(&startTime_, 0);
-	if (!Connect(result))
-	{
-		Reset();
-		log_warn("Could not connect to server.");
-		return false;
-	}
-	return true;
+    Value result = Value(ValueType::InvalidType);
+    gettimeofday(&startTime_, 0);
+    if (!Connect(result))
+    {
+        Reset();
+        log_warn("Could not connect to server.");
+        return false;
+    }
+    return true;
 }
 
 bool Client::Connect(Value& result)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -31,6 +31,12 @@
 #include "anyrpc/client.h"
 #include "anyrpc/internal/time.h"
 
+#ifndef WIN32
+#include <sys/socket.h>
+#include <netinet/ip.h>
+#include <arpa/inet.h>
+#endif  // _WIN32
+
 namespace anyrpc
 {
 
@@ -292,6 +298,20 @@ unsigned Client::GetTimeLeft()
 
     log_debug("GetTimeLeft: timeout=" << timeout_ << ", timeLeft=" << timeLeft << ", timeUsed=" << timeUsed);
     return timeLeft;
+}
+
+//! Start the client and connect to server
+bool Client::Start()
+{
+	Value result = Value(ValueType::InvalidType);
+	gettimeofday(&startTime_, 0);
+	if (!Connect(result))
+	{
+		Reset();
+		log_warn("Could not connect to server.");
+		return false;
+	}
+	return true;
 }
 
 bool Client::Connect(Value& result)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -157,8 +157,8 @@ void Server::Exit()
 void Server::StartThread()
 {
     log_trace();
-	threadRunning_ = true;
-	thread_ = std::thread(&Server::ThreadStarter, this);
+    threadRunning_ = true;
+    thread_ = std::thread(&Server::ThreadStarter, this);
 }
 
 void Server::StopThread()
@@ -173,7 +173,7 @@ void Server::StopThread()
 
 void Server::ThreadStarter()
 {
-	log_trace();
+    log_trace();
     while (threadRunning_ && !exit_)
     {
         Work(100);
@@ -185,26 +185,26 @@ void Server::ThreadStarter()
 
 void Server::GetConnectionsSockInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const
 {
-	std::string ip;
-	unsigned port;
-	for (auto& client : connections_)
-	{
-		client->GetSockInfo(ip, port);
-		ips.push_back(ip);
-		ports.push_back(port);
-	}
+    std::string ip;
+    unsigned port;
+    for (auto& client : connections_)
+    {
+        client->GetSockInfo(ip, port);
+        ips.push_back(ip);
+        ports.push_back(port);
+    }
 }
 
 void Server::GetConnectionsPeerInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const
 {
-	std::string ip;
-	unsigned port;
-	for (auto& client : connections_)
-	{
-		client->GetPeerInfo(ip, port);
-		ips.push_back(ip);
-		ports.push_back(port);
-	}
+    std::string ip;
+    unsigned port;
+    for (auto& client : connections_)
+    {
+        client->GetPeerInfo(ip, port);
+        ips.push_back(ip);
+        ports.push_back(port);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -546,8 +546,8 @@ void ServerTP::ThreadStarter()
     workerBlock_.notify_all();
     for (std::thread &worker: workers_)
         worker.join();
-	workers_.clear();
-	
+    workers_.clear();
+    
     // shutdown the rest of the system
     Shutdown();
     threadRunning_ = false;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -89,7 +89,7 @@ bool Server::BindAndListen(int port, int backlog)
     if (result != 0)
     {
         socket_.Close();
-        log_warn("Could not bind to specified port : " << result);
+        log_warn("Could not bind to specified port " << port << " : " << result);
         return false;
     }
 
@@ -182,6 +182,30 @@ void Server::ThreadStarter()
     threadRunning_ = false;
 }
 #endif // defined(ANYRPC_THREADING)
+
+void Server::GetConnectionsSockInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const
+{
+	std::string ip;
+	unsigned port;
+	for (auto& client : connections_)
+	{
+		client->GetSockInfo(ip, port);
+		ips.push_back(ip);
+		ports.push_back(port);
+	}
+}
+
+void Server::GetConnectionsPeerInfo(std::list<std::string>& ips, std::list<unsigned>& ports) const
+{
+	std::string ip;
+	unsigned port;
+	for (auto& client : connections_)
+	{
+		client->GetPeerInfo(ip, port);
+		ips.push_back(ip);
+		ports.push_back(port);
+	}
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -564,7 +588,7 @@ bool ServerTP::BindAndListen(int port, int backlog)
     if (result != 0)
     {
         serverSignal_.Close();
-        log_warn("Could not bind to specified port : " << result);
+        log_warn("Could not bind to specified port " << port << ": " << result);
         return false;
     }
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -258,6 +258,44 @@ bool Socket::WaitWritable(int timeout)
     return true;
 }
 
+bool Socket::GetSockInfo(std::string& ip, unsigned& port) const
+{
+	// get socket local ip and local port
+	sockaddr_in sa;
+	socklen_t len = sizeof(struct sockaddr_in);
+	if (getsockname(fd_, (struct sockaddr *) &sa, &len) != 0)
+	{
+		log_warn("Error while calling getsockname (code " << errno << "). Could not identify local ip and port of socket.");
+		return false;
+	}
+	// convert information
+	char ipStr[20];
+	inet_ntop(sa.sin_family, &sa.sin_addr, ipStr, sizeof(ipStr));
+	ip = ipStr;
+	port = ntohs(sa.sin_port);
+	log_debug("Socket information: " << ip << " on port " << port );
+	return true;
+}
+
+bool Socket::GetPeerInfo(std::string& ip, unsigned& port) const
+{
+	// get ip and port of connected peer
+	struct sockaddr_in sa;
+	socklen_t len = sizeof(struct sockaddr_in);
+	if (getpeername(fd_, (struct sockaddr *)&sa, &len) != 0)
+	{
+		log_warn("Error while calling getpeername (code " << errno << "). Could not identify ip and port of peer.");
+		return false;
+	}
+	// convert information
+	char ipStr[20];
+	inet_ntop(sa.sin_family, &sa.sin_addr, ipStr, sizeof(ipStr));
+	ip = ipStr;
+	port = ntohs(sa.sin_port);
+	log_debug("Peer information: " << ip << " on port " << port);
+	return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 SOCKET TcpSocket::Create()

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -260,40 +260,40 @@ bool Socket::WaitWritable(int timeout)
 
 bool Socket::GetSockInfo(std::string& ip, unsigned& port) const
 {
-	// get socket local ip and local port
-	sockaddr_in sa;
-	socklen_t len = sizeof(struct sockaddr_in);
-	if (getsockname(fd_, (struct sockaddr *) &sa, &len) != 0)
-	{
-		log_warn("Error while calling getsockname (code " << errno << "). Could not identify local ip and port of socket.");
-		return false;
-	}
-	// convert information
-	char ipStr[20];
-	inet_ntop(sa.sin_family, &sa.sin_addr, ipStr, sizeof(ipStr));
-	ip = ipStr;
-	port = ntohs(sa.sin_port);
-	log_debug("Socket information: " << ip << " on port " << port );
-	return true;
+    // get socket local ip and local port
+    sockaddr_in sa;
+    socklen_t len = sizeof(struct sockaddr_in);
+    if (getsockname(fd_, (struct sockaddr *) &sa, &len) != 0)
+    {
+        log_warn("Error while calling getsockname (code " << errno << "). Could not identify local ip and port of socket.");
+        return false;
+    }
+    // convert information
+    char ipStr[20];
+    inet_ntop(sa.sin_family, &sa.sin_addr, ipStr, sizeof(ipStr));
+    ip = ipStr;
+    port = ntohs(sa.sin_port);
+    log_debug("Socket information: " << ip << " on port " << port );
+    return true;
 }
 
 bool Socket::GetPeerInfo(std::string& ip, unsigned& port) const
 {
-	// get ip and port of connected peer
-	struct sockaddr_in sa;
-	socklen_t len = sizeof(struct sockaddr_in);
-	if (getpeername(fd_, (struct sockaddr *)&sa, &len) != 0)
-	{
-		log_warn("Error while calling getpeername (code " << errno << "). Could not identify ip and port of peer.");
-		return false;
-	}
-	// convert information
-	char ipStr[20];
-	inet_ntop(sa.sin_family, &sa.sin_addr, ipStr, sizeof(ipStr));
-	ip = ipStr;
-	port = ntohs(sa.sin_port);
-	log_debug("Peer information: " << ip << " on port " << port);
-	return true;
+    // get ip and port of connected peer
+    struct sockaddr_in sa;
+    socklen_t len = sizeof(struct sockaddr_in);
+    if (getpeername(fd_, (struct sockaddr *)&sa, &len) != 0)
+    {
+        log_warn("Error while calling getpeername (code " << errno << "). Could not identify ip and port of peer.");
+        return false;
+    }
+    // convert information
+    char ipStr[20];
+    inet_ntop(sa.sin_family, &sa.sin_addr, ipStr, sizeof(ipStr));
+    ip = ipStr;
+    port = ntohs(sa.sin_port);
+    log_debug("Peer information: " << ip << " on port " << port);
+    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
My motivation for this functionality was, that I needed to know ip and port of my connecting client and server. I'm working with a multi client- multi server network and therefor having this information is usefull for logging and debugging purposes. Besides it can be used to start the second side of a two-directional rpc-interface.

As described in the commit message, the Socket provides basic functionality while Server, Client and Connection just pass the request on.

Asking for ip and port however is not possible, before the connection is established. Besides implicit start of a connection when calling Notify, Call or Post, I didn't find any functionality which actually establishes a connection. I figured, that an empty dummy message for starting connection is not the best way, so I provided the Client::Start() functionality. Maybe you have a closer look on it, I'm not 100% sure, if it is implemented correctly. In particular I'm not sure with `gettimeofday(&startTime_, 0);`, but without the call of Connect() fails.

Of course it's not required in general, but only if you want to get your port / ip before sending first tcprpc message.

The functionality is tested with Visual Studio 2015, Windows 7 and gcc 4.9.2, Linux.