### PR TITLE
Endianness detection on ARM

### DIFF
--- a/include/anyrpc/api.h
+++ b/include/anyrpc/api.h
@@ -158,9 +158,9 @@ typedef int socklen_t;
 #  elif defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN)
 #    define ANYRPC_ENDIAN ANYRPC_BIGENDIAN
 // Detect with architecture macros
-#  elif defined(__sparc) || defined(__sparc__) || defined(_POWER) || defined(__powerpc__) || defined(__ppc__) || defined(__hpux) || defined(__hppa) || defined(_MIPSEB) || defined(_POWER) || defined(__s390__)
+#  elif defined(__sparc) || defined(__sparc__) || defined(_POWER) || defined(__powerpc__) || defined(__ppc__) || defined(__hpux) || defined(__hppa) || defined(_MIPSEB) || defined(_POWER) || defined(__s390__) || defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__)
 #    define ANYRPC_ENDIAN ANYRPC_BIGENDIAN
-#  elif defined(__i386__) || defined(__alpha__) || defined(__ia64) || defined(__ia64__) || defined(_M_IX86) || defined(_M_IA64) || defined(_M_ALPHA) || defined(__amd64) || defined(__amd64__) || defined(_M_AMD64) || defined(__x86_64) || defined(__x86_64__) || defined(_M_X64) || defined(__bfin__)
+#  elif defined(__i386__) || defined(__alpha__) || defined(__ia64) || defined(__ia64__) || defined(_M_IX86) || defined(_M_IA64) || defined(_M_ALPHA) || defined(__amd64) || defined(__amd64__) || defined(_M_AMD64) || defined(__x86_64) || defined(__x86_64__) || defined(_M_X64) || defined(__bfin__) || defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || defined(_M_ARM64) || defined(_M_ARM)
 #    define ANYRPC_ENDIAN ANYRPC_LITTLEENDIAN
 #  elif defined(ANYRPC_DOXYGEN_RUNNING)
 #    define ANYRPC_ENDIAN


### PR DESCRIPTION
These changes have made it possible for me to add anyrpc to vcpkg (currently via patchfile) and are already in use there. Would be great to have them in the upstream repo :)

> Added more compile-flag checks to determine endianness on ARM.
> The flags `_M_ARM64` and `_M_ARM` are set by MS VisualStudio when
> compiling for windows on ARM. This only supports little endian
> on ARM and thus it is safe to assume little endianness in these
> cases.